### PR TITLE
:bug: Fix Blog "Other Posts" Button

### DIFF
--- a/themes/hello-friend-ng/layouts/partials/pagination-single.html
+++ b/themes/hello-friend-ng/layouts/partials/pagination-single.html
@@ -8,19 +8,19 @@
         {{ end }}
 
         <div class="pagination__buttons">
-            {{ if .NextInSection }}
+            {{ if .PrevInSection }}
             <span class="button previous">
-                <a href="{{ .NextInSection.Permalink }}">
+                <a href="{{ .PrevInSection.Permalink }}">
                     <span class="button__icon">←</span>
-                    <span class="button__text">{{ .NextInSection.Title }}</span>
+                    <span class="button__text">{{ .PrevInSection.Title }}</span>
                 </a>
             </span>
             {{ end }}
 
-            {{ if .PrevInSection }}
+            {{ if .NextInSection }}
             <span class="button next">
-                <a href="{{ .PrevInSection.Permalink }}">
-                    <span class="button__text">{{ .PrevInSection.Title }}</span>
+                <a href="{{ .NextInSection.Permalink }}">
+                    <span class="button__text">{{ .NextInSection.Title }}</span>
                     <span class="button__icon">→</span>
                 </a>
             </span>


### PR DESCRIPTION
Buttons were the wrong way around with arrows pointing to the right for older posts and arrows pointing left for newer posts.